### PR TITLE
mingw-w64-curl: 7.50.2 - update to latest version

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -6,7 +6,7 @@ _variant=-openssl
 _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=7.50.1
+pkgver=7.50.2
 pkgrel=1
 pkgdesc="An URL retrival utility and library. (mingw-w64)"
 arch=('any')
@@ -32,7 +32,7 @@ options=('staticlibs')
 source=("${url}/download/${_realname}-${pkgver}.tar.bz2"{,.asc}
         "0001-curl-relocation.patch"
         "0004-cURL-Get-relocatable-base-from-dll.patch")
-sha256sums=('3c12c5f54ccaa1d40abc65d672107dcc75d3e1fcb38c267484334280096e5156'
+sha256sums=('0c72105df4e9575d68bcf43aea1751056c1d29b1040df6194a49c5ac08f8e233'
             'SKIP'
             '3aa3e42dc35daba84470def39d7b6e16ce15f3397e99d341b844d8cd8796bab5'
             'e21fb106ebda8559ba2d34633a9d7d94be541de02de01982f92d67048bb9854b')


### PR DESCRIPTION
Bumping this package to get this fix https://github.com/curl/curl/pull/959

cc @dscho